### PR TITLE
password utils are available directly from the package

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ You can use the provided utility functions to generate password hashes:
 import {
   generatePasswordHash,
   generateUserObject,
-} from "@tuagye/swagger-auth-middleware/passwordUtils";
+} from "@tuagye/swagger-auth-middleware";
 
 // Generate a single password hash
 async function hashSinglePassword() {


### PR DESCRIPTION
import password functions from the main file since it's exported from there. No need to access the `passwordUtils` file